### PR TITLE
Fix move layer up

### DIFF
--- a/assets/gui_root.tscn
+++ b/assets/gui_root.tscn
@@ -387,8 +387,8 @@ mode = 1
 access = 2
 filters = PoolStringArray( "*.png; PNG Files" )
 show_hidden_files = true
-current_dir = "/Toby/Documents/MY OWN FILES/Programming/BetterSkin2"
-current_path = "/Toby/Documents/MY OWN FILES/Programming/BetterSkin2/"
+current_dir = "/home/hitcoder/Documents/GodotProjects/BetterSkin2"
+current_path = "/home/hitcoder/Documents/GodotProjects/BetterSkin2/"
 script = ExtResource( 9 )
 
 [node name="ExportPNGDialog" type="FileDialog" parent="GlobalDialogs"]
@@ -406,8 +406,8 @@ resizable = true
 access = 2
 filters = PoolStringArray( "*.png; PNG Files" )
 show_hidden_files = true
-current_dir = "/Toby/Documents/MY OWN FILES/Programming/BetterSkin2"
-current_path = "/Toby/Documents/MY OWN FILES/Programming/BetterSkin2/"
+current_dir = "/home/hitcoder/Documents/GodotProjects/BetterSkin2"
+current_path = "/home/hitcoder/Documents/GodotProjects/BetterSkin2/"
 script = ExtResource( 10 )
 
 [node name="PreferencesDialog" type="WindowDialog" parent="GlobalDialogs"]

--- a/assets/main_viewport/3d_panel/3DWorld.tscn
+++ b/assets/main_viewport/3d_panel/3DWorld.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://arts/grass_block_side.png" type="Texture" id=1]
-[ext_resource path="res://assets/main_viewport/3d_panel/3Dworld.gd" type="Script" id=2]
+[ext_resource path="res://assets/main_viewport/3d_panel/3DWorld.gd" type="Script" id=2]
 [ext_resource path="res://assets/main_viewport/3d_panel/model/rig_basic.tscn" type="PackedScene" id=3]
 [ext_resource path="res://assets/main_viewport/3d_panel/uv_viewport.gd" type="Script" id=4]
 [ext_resource path="res://assets/main_viewport/3d_panel/uv_world.tres" type="World" id=5]

--- a/scripts/document_manager.gd
+++ b/scripts/document_manager.gd
@@ -150,7 +150,7 @@ func pop_layer(at_index: int = 0) -> SkinLayer:
 	assert(at_index >= 0 and at_index < self.active_skin.layers.size(),
 			"index out of range")
 	var ret = self.active_skin.layers.pop_at(at_index)
-	if at_index <= self.active_layer_index:
+	if at_index <= self.active_layer_index and self.active_layer_index > 0:
 		self.active_layer_index -= 1
 	queue_emit_layers_changed()
 	queue_render_skin()


### PR DESCRIPTION
Fix bug where clicking the up button on the layer editor with the bottom-most layer selected will cause a crash due to attempting to decrement the index to -1.