### PR TITLE
Connect blend slider to alpha of layer

### DIFF
--- a/assets/layer_dropdown/layer_dropdown.tscn
+++ b/assets/layer_dropdown/layer_dropdown.tscn
@@ -12,9 +12,6 @@ text = "LayerChooser"
 items = [ "LayerChooser", null, false, 0, null ]
 selected = 0
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="RightClickButton" type="ToolButton" parent="."]
 anchor_right = 1.0
@@ -114,6 +111,7 @@ text = "delete"
 
 [connection signal="item_selected" from="." to="." method="_on_LayersDropdown_item_selected"]
 [connection signal="pressed" from="RightClickButton" to="." method="_on_RightClickButton_pressed"]
+[connection signal="value_changed" from="LayerEditorPanel/VBox/BlendSlider" to="LayerEditorPanel/VBox/Layers" method="_on_BlendSlider_value_changed"]
 [connection signal="button_pressed" from="LayerEditorPanel/VBox/Layers" to="LayerEditorPanel/VBox/Layers" method="_on_Layers_button_pressed"]
 [connection signal="item_edited" from="LayerEditorPanel/VBox/Layers" to="LayerEditorPanel/VBox/Layers" method="_on_Layers_item_edited"]
 [connection signal="item_rmb_selected" from="LayerEditorPanel/VBox/Layers" to="LayerEditorPanel/VBox/Layers" method="_on_Layers_item_rmb_selected"]

--- a/assets/layer_dropdown/tree_list.gd
+++ b/assets/layer_dropdown/tree_list.gd
@@ -53,6 +53,8 @@ func _sync_active_layer():
 	var layer_idx = DocumentManager.active_layer_index
 	var tree_idx = DocumentManager.layers.size() - 1 - layer_idx
 	self._set_active(tree_idx)
+	var blend = get_node("../BlendSlider") as HSlider
+	blend.value = DocumentManager.active_layer.alpha*100
 
 
 func _set_active(index: int):
@@ -139,3 +141,7 @@ func _on_LayersMenu_id_pressed(id: int) -> void:
 			DocumentManager.pop_layer(DocumentManager.active_layer_index)
 		CST.TreeMenu.MERGE_DOWN:
 			pass
+
+
+func _on_BlendSlider_value_changed(value):
+	DocumentManager.active_layer.alpha = get_node("../BlendSlider").value / 100


### PR DESCRIPTION
opacity value per layer will now save to the layer when adjusted, and opening images will set the slider value relative to the alpha value.

currently the alpha value of the layer is not visible on the rendered preview, and I'm not really sure how to tackle this efficiently, so hope somebody else could take care of this for now.